### PR TITLE
Removed universal css for all cards

### DIFF
--- a/src/Registration/Registration.css
+++ b/src/Registration/Registration.css
@@ -3,7 +3,7 @@
     height: 100%;
 }
 
-.card {
+.recipe-card {
     padding: 3em;
     position: fixed;
     max-width: 40em;


### PR DESCRIPTION
- Current registration.css destroys the cards on the feed because the identifier is ".card" which targets all the cards in our app. Renamed this to the id of the registration card