### PR TITLE
Persistent login #102

### DIFF
--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -1,17 +1,28 @@
 import React, { useEffect, useState } from "react";
 import firebase from "firebase";
+import "bootstrap/dist/css/bootstrap.min.css";
+import { Spinner } from "react-bootstrap";
 import PropTypes from "prop-types";
 
 export const AuthContext = React.createContext();
 
 export const AuthProvider = ({ children }) => {
   const [currentUser, setCurrentUser] = useState(null);
+  const [pending, setPending] = useState(true);
 
+  // Check if user is still logged in on every page load.
   useEffect(() => {
-    firebase.auth().onAuthStateChanged(setCurrentUser);
+    firebase.auth().onAuthStateChanged((user) => {
+      setCurrentUser(user);
+      setPending(false);
+    });
   }, []);
 
-  return (
+  // If the state of the currentUser isn't verified yet,
+  // we return a loading spinner.
+  return pending ? (
+    <Spinner animation="border" variant="danger" />
+  ) : (
     <AuthContext.Provider value={{ currentUser }}>
       {children}
     </AuthContext.Provider>


### PR DESCRIPTION
After logging in, you can navigate from home to any other private route (in this case "Add recipe")

Haven't added any styling to the spinner. This should be positioned in the middle with a global css rule (like every other page)