### PR TITLE
Hotfix/user ID in recipe #100

### DIFF
--- a/src/CreateRecipe/CreateRecipe.jsx
+++ b/src/CreateRecipe/CreateRecipe.jsx
@@ -20,6 +20,7 @@ export default function CreateRecipe() {
     } = event.target.elements;
 
     const ref = firebase.firestore().collection("recipe").doc();
+    const userUid = firebase.auth().currentUser.uid;
     ref
       .set({
         id: ref.id,
@@ -28,6 +29,7 @@ export default function CreateRecipe() {
         description: description.value,
         cookingTime: cookingTime.value,
         ingredients: ingredients.value,
+        createdBy: userUid,
       })
       .catch((e) => setError(e));
 


### PR DESCRIPTION
The user UID is now saved to the recipe as 'createdBy' when the logged in user creates a recipe.